### PR TITLE
Alert policies

### DIFF
--- a/include/test_fixture.hrl
+++ b/include/test_fixture.hrl
@@ -52,5 +52,6 @@ maybe_call_function(F, A) ->
 -define( seq(S), meck:seq(S) ).
 
 -define( called( M, F, A), ?assert( meck:called( M, F, A ) ) ).
+-define( not_called( M, F, A), ?assertNot( meck:called( M, F, A ) ) ).
 -define( capture_when(When, Method, Function, Arity, CapturePosition), meck:capture(case When of second -> 2; _ -> When end, Method, Function, ['_' || _ <- lists:seq(1, Arity)], CapturePosition) ).
 -define( capture(Method, Function, Arity, CapturePosition), ?capture_when(first, Method, Function, Arity, CapturePosition) ).

--- a/src/clc_v2.erl
+++ b/src/clc_v2.erl
@@ -40,7 +40,7 @@ alert_policy(Ref, Id) ->
 create_alert_policy(Ref, Spec) ->
    clc_v2_alert_policies:create(Ref, Spec).
 
--spec update_alert_policy(Ref::clc_v2_auth:auth_ref(), Spec::map, Id::binary()) -> binary().
+-spec update_alert_policy(Ref::clc_v2_auth:auth_ref(), Spec::map, Id::binary()) -> ok.
 update_alert_policy(Ref, Spec, Id) ->
    clc_v2_alert_policies:update(Ref, Spec, Id).
 

--- a/src/clc_v2.erl
+++ b/src/clc_v2.erl
@@ -5,7 +5,8 @@
   datacenter/2,
   datacenter_capabilities/2,
   alert_policies/1,
-  alert_policy/2
+  alert_policy/2,
+  create_alert_policy/2
   ] ).
 
 -spec login( Username::binary(), Password::binary() ) -> clc_v2_auth:auth_ref().
@@ -32,3 +33,7 @@ alert_policies(Ref) ->
 -spec alert_policy(Ref::clc_v2_auth:auth_ref(), Id::binary()) -> map().
 alert_policy(Ref, Id) ->
    clc_v2_alert_policies:get(Ref, Id).
+
+-spec create_alert_policy(Ref::clc_v2_auth:auth_ref(), Spec::map) -> binary().
+create_alert_policy(_Ref, _Spec) ->
+  ok.

--- a/src/clc_v2.erl
+++ b/src/clc_v2.erl
@@ -6,7 +6,8 @@
   datacenter_capabilities/2,
   alert_policies/1,
   alert_policy/2,
-  create_alert_policy/2
+  create_alert_policy/2,
+  update_alert_policy/3
   ] ).
 
 -spec login( Username::binary(), Password::binary() ) -> clc_v2_auth:auth_ref().
@@ -37,3 +38,7 @@ alert_policy(Ref, Id) ->
 -spec create_alert_policy(Ref::clc_v2_auth:auth_ref(), Spec::map) -> binary().
 create_alert_policy(Ref, Spec) ->
    clc_v2_alert_policies:create(Ref, Spec).
+
+-spec update_alert_policy(Ref::clc_v2_auth:auth_ref(), Spec::map, Id::binary()) -> binary().
+update_alert_policy(_Ref, _Spec, _Id) ->
+   ok.

--- a/src/clc_v2.erl
+++ b/src/clc_v2.erl
@@ -35,5 +35,5 @@ alert_policy(Ref, Id) ->
    clc_v2_alert_policies:get(Ref, Id).
 
 -spec create_alert_policy(Ref::clc_v2_auth:auth_ref(), Spec::map) -> binary().
-create_alert_policy(_Ref, _Spec) ->
-  ok.
+create_alert_policy(Ref, Spec) ->
+   clc_v2_alert_policies:create(Ref, Spec).

--- a/src/clc_v2.erl
+++ b/src/clc_v2.erl
@@ -46,4 +46,4 @@ update_alert_policy(Ref, Spec, Id) ->
 
 -spec delete_alert_policy(Ref::clc_v2_auth:auth_ref(), Id::binary()) -> ok.
 delete_alert_policy(Ref, Id) ->
-   ok.
+   clc_v2_alert_policies:delete(Ref, Id).

--- a/src/clc_v2.erl
+++ b/src/clc_v2.erl
@@ -40,5 +40,5 @@ create_alert_policy(Ref, Spec) ->
    clc_v2_alert_policies:create(Ref, Spec).
 
 -spec update_alert_policy(Ref::clc_v2_auth:auth_ref(), Spec::map, Id::binary()) -> binary().
-update_alert_policy(_Ref, _Spec, _Id) ->
-   ok.
+update_alert_policy(Ref, Spec, Id) ->
+   clc_v2_alert_policies:update(Ref, Spec, Id).

--- a/src/clc_v2.erl
+++ b/src/clc_v2.erl
@@ -7,7 +7,8 @@
   alert_policies/1,
   alert_policy/2,
   create_alert_policy/2,
-  update_alert_policy/3
+  update_alert_policy/3,
+  delete_alert_policy/2
   ] ).
 
 -spec login( Username::binary(), Password::binary() ) -> clc_v2_auth:auth_ref().
@@ -42,3 +43,7 @@ create_alert_policy(Ref, Spec) ->
 -spec update_alert_policy(Ref::clc_v2_auth:auth_ref(), Spec::map, Id::binary()) -> binary().
 update_alert_policy(Ref, Spec, Id) ->
    clc_v2_alert_policies:update(Ref, Spec, Id).
+
+-spec delete_alert_policy(Ref::clc_v2_auth:auth_ref(), Id::binary()) -> ok.
+delete_alert_policy(Ref, Id) ->
+   ok.

--- a/src/clc_v2.erl
+++ b/src/clc_v2.erl
@@ -13,8 +13,7 @@
 
 -spec login( Username::binary(), Password::binary() ) -> clc_v2_auth:auth_ref().
 login( Username, Password ) ->
-  { ok, AuthRef } = clc_v2_auth_sup:create_worker( Username, Password ),
-  AuthRef.
+  clc_v2_auth_sup:create_worker( Username, Password ).
 
 -spec datacenters(Ref::clc_v2_auth:auth_ref()) -> map().
 datacenters(Ref) ->

--- a/src/clc_v2.erl
+++ b/src/clc_v2.erl
@@ -4,7 +4,8 @@
   datacenters/1,
   datacenter/2,
   datacenter_capabilities/2,
-  alert_policies/1
+  alert_policies/1,
+  alert_policy/2
   ] ).
 
 -spec login( Username::binary(), Password::binary() ) -> clc_v2_auth:auth_ref().
@@ -27,3 +28,7 @@ datacenter_capabilities(Ref, Datacenter) ->
 -spec alert_policies(Ref::clc_v2_auth:auth_ref()) -> map().
 alert_policies(Ref) ->
    clc_v2_alert_policies:get(Ref).
+
+-spec alert_policy(Ref::clc_v2_auth:auth_ref(), Id::binary()) -> map().
+alert_policy(Ref, Id) ->
+   clc_v2_alert_policies:get(Ref, Id).

--- a/src/clc_v2_alert_policies.erl
+++ b/src/clc_v2_alert_policies.erl
@@ -2,7 +2,8 @@
 
 -export([
   get/1,
-  get/2
+  get/2,
+  create/2
   ]).
 
 -spec get( AuthRef::clc_v2_auth:auth_ref() ) -> map().
@@ -14,3 +15,16 @@ get( AuthRef ) ->
 get( AuthRef, Id ) ->
   {ok, Policy } = clc_v2_http_client:get( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ] ),
   Policy.
+
+-spec create( AuthRef::clc_v2_auth:auth_ref(), Spec::map() ) -> binary().
+create( AuthRef, Spec ) ->
+  Spec1 = to_api_spec(Spec),
+  {ok, #{ <<"id">> := Id } } = clc_v2_http_client:post( AuthRef, ["alertPolicies", account_alias ], Spec1 ),
+  Id.
+
+to_api_spec( #{ name := Name, email_recipients := Recipients, triggers := Triggers } ) ->
+  #{ name => Name,
+     actions => [ #{ action => email,
+                     settings => #{ recipients => Recipients } } ],
+     triggers => Triggers
+   }.

--- a/src/clc_v2_alert_policies.erl
+++ b/src/clc_v2_alert_policies.erl
@@ -24,14 +24,16 @@ create( AuthRef, Spec ) ->
   {ok, #{ <<"id">> := Id } } = clc_v2_http_client:post( AuthRef, ["alertPolicies", account_alias ], Spec1 ),
   Id.
 
--spec update( AuthRef::clc_v2_auth:auth_ref(), Spec::map(), Id::binary() ) -> binary().
+-spec update( AuthRef::clc_v2_auth:auth_ref(), Spec::map(), Id::binary() ) -> ok.
 update( AuthRef, Spec, Id ) ->
   Spec1 = to_api_spec(Spec),
-  clc_v2_http_client:put( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ], Spec1 ).
+  clc_v2_http_client:put( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ], Spec1 ),
+  ok.
 
 -spec delete( AuthRef::clc_v2_auth:auth_ref(), Id::binary() ) -> ok.
 delete( AuthRef, Id ) ->
-  clc_v2_http_client:delete( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ] ).
+  clc_v2_http_client:delete( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ] ),
+  ok.
 
 to_api_spec( #{ name := Name, email_recipients := Recipients, triggers := Triggers } ) ->
   #{ name => Name,

--- a/src/clc_v2_alert_policies.erl
+++ b/src/clc_v2_alert_policies.erl
@@ -18,11 +18,15 @@ get( AuthRef, Id ) ->
   {ok, Policy } = clc_v2_http_client:get( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ] ),
   Policy.
 
--spec create( AuthRef::clc_v2_auth:auth_ref(), Spec::map() ) -> binary().
+-spec create( AuthRef::clc_v2_auth:auth_ref(), Spec::map() ) -> binary() | { error, term() }.
 create( AuthRef, Spec ) ->
   Spec1 = to_api_spec(Spec),
-  {ok, #{ <<"id">> := Id } } = clc_v2_http_client:post( AuthRef, ["alertPolicies", account_alias ], Spec1 ),
-  Id.
+  Response = clc_v2_http_client:post( AuthRef, ["alertPolicies", account_alias ], Spec1 ),
+
+  case Response of
+    {ok, #{ <<"id">> := Id } } -> Id;
+    Error -> Error
+  end.
 
 -spec update( AuthRef::clc_v2_auth:auth_ref(), Spec::map(), Id::binary() ) -> ok.
 update( AuthRef, Spec, Id ) ->

--- a/src/clc_v2_alert_policies.erl
+++ b/src/clc_v2_alert_policies.erl
@@ -20,7 +20,6 @@ get( AuthRef, Id ) ->
 create( AuthRef, Spec ) ->
   Spec1 = to_api_spec(Spec),
   Response = clc_v2_http_client:post( AuthRef, ["alertPolicies", account_alias ], Spec1 ),
-
   case Response of
     {ok, #{ <<"id">> := Id } } -> { ok, Id };
     Error -> Error
@@ -29,13 +28,19 @@ create( AuthRef, Spec ) ->
 -spec update( AuthRef::clc_v2_auth:auth_ref(), Spec::map(), Id::binary() ) -> ok.
 update( AuthRef, Spec, Id ) ->
   Spec1 = to_api_spec(Spec),
-  clc_v2_http_client:put( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ], Spec1 ),
-  ok.
+  Response = clc_v2_http_client:put( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ], Spec1 ),
+  case Response of
+    { ok, _ } -> ok;
+    Error -> Error
+  end.
 
 -spec delete( AuthRef::clc_v2_auth:auth_ref(), Id::binary() ) -> ok.
 delete( AuthRef, Id ) ->
-  clc_v2_http_client:delete( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ] ),
-  ok.
+  Response = clc_v2_http_client:delete( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ] ),
+  case Response of
+    { ok, _ } -> ok;
+    Error -> Error
+  end.
 
 to_api_spec( #{ name := Name, email_recipients := Recipients, triggers := Triggers } ) ->
   #{ name => Name,

--- a/src/clc_v2_alert_policies.erl
+++ b/src/clc_v2_alert_policies.erl
@@ -3,7 +3,8 @@
 -export([
   get/1,
   get/2,
-  create/2
+  create/2,
+  update/3
   ]).
 
 -spec get( AuthRef::clc_v2_auth:auth_ref() ) -> map().
@@ -21,6 +22,11 @@ create( AuthRef, Spec ) ->
   Spec1 = to_api_spec(Spec),
   {ok, #{ <<"id">> := Id } } = clc_v2_http_client:post( AuthRef, ["alertPolicies", account_alias ], Spec1 ),
   Id.
+
+-spec update( AuthRef::clc_v2_auth:auth_ref(), Spec::map(), Id::binary() ) -> binary().
+update( AuthRef, Spec, Id ) ->
+  Spec1 = to_api_spec(Spec),
+  clc_v2_http_client:put( AuthRef, ["alertPolicies", account_alias, Id ], Spec1 ).
 
 to_api_spec( #{ name := Name, email_recipients := Recipients, triggers := Triggers } ) ->
   #{ name => Name,

--- a/src/clc_v2_alert_policies.erl
+++ b/src/clc_v2_alert_policies.erl
@@ -26,7 +26,7 @@ create( AuthRef, Spec ) ->
 -spec update( AuthRef::clc_v2_auth:auth_ref(), Spec::map(), Id::binary() ) -> binary().
 update( AuthRef, Spec, Id ) ->
   Spec1 = to_api_spec(Spec),
-  clc_v2_http_client:put( AuthRef, ["alertPolicies", account_alias, Id ], Spec1 ).
+  clc_v2_http_client:put( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ], Spec1 ).
 
 to_api_spec( #{ name := Name, email_recipients := Recipients, triggers := Triggers } ) ->
   #{ name => Name,

--- a/src/clc_v2_alert_policies.erl
+++ b/src/clc_v2_alert_policies.erl
@@ -1,10 +1,16 @@
 -module( clc_v2_alert_policies ).
 
 -export([
-  get/1
+  get/1,
+  get/2
   ]).
 
 -spec get( AuthRef::clc_v2_auth:auth_ref() ) -> map().
 get( AuthRef ) ->
-  {ok, Alerts } = clc_v2_http_client:get( AuthRef, ["alertPolicies", account_alias ] ),
-  Alerts.
+  {ok, Policies}  = clc_v2_http_client:get( AuthRef, ["alertPolicies", account_alias ] ),
+  Policies.
+
+-spec get( AuthRef::clc_v2_auth:auth_ref(), Id::binary() ) -> map().
+get( AuthRef, Id ) ->
+  {ok, Policy } = clc_v2_http_client:get( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ] ),
+  Policy.

--- a/src/clc_v2_alert_policies.erl
+++ b/src/clc_v2_alert_policies.erl
@@ -4,7 +4,8 @@
   get/1,
   get/2,
   create/2,
-  update/3
+  update/3,
+  delete/2
   ]).
 
 -spec get( AuthRef::clc_v2_auth:auth_ref() ) -> map().
@@ -27,6 +28,10 @@ create( AuthRef, Spec ) ->
 update( AuthRef, Spec, Id ) ->
   Spec1 = to_api_spec(Spec),
   clc_v2_http_client:put( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ], Spec1 ).
+
+-spec delete( AuthRef::clc_v2_auth:auth_ref(), Id::binary() ) -> ok.
+delete( AuthRef, Id ) ->
+  clc_v2_http_client:delete( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ] ).
 
 to_api_spec( #{ name := Name, email_recipients := Recipients, triggers := Triggers } ) ->
   #{ name => Name,

--- a/src/clc_v2_alert_policies.erl
+++ b/src/clc_v2_alert_policies.erl
@@ -10,13 +10,11 @@
 
 -spec get( AuthRef::clc_v2_auth:auth_ref() ) -> map().
 get( AuthRef ) ->
-  {ok, Policies}  = clc_v2_http_client:get( AuthRef, ["alertPolicies", account_alias ] ),
-  Policies.
+  clc_v2_http_client:get( AuthRef, ["alertPolicies", account_alias ] ).
 
 -spec get( AuthRef::clc_v2_auth:auth_ref(), Id::binary() ) -> map().
 get( AuthRef, Id ) ->
-  {ok, Policy } = clc_v2_http_client:get( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ] ),
-  Policy.
+  clc_v2_http_client:get( AuthRef, ["alertPolicies", account_alias, binary_to_list(Id) ] ).
 
 -spec create( AuthRef::clc_v2_auth:auth_ref(), Spec::map() ) -> binary() | { error, term() }.
 create( AuthRef, Spec ) ->
@@ -24,7 +22,7 @@ create( AuthRef, Spec ) ->
   Response = clc_v2_http_client:post( AuthRef, ["alertPolicies", account_alias ], Spec1 ),
 
   case Response of
-    {ok, #{ <<"id">> := Id } } -> Id;
+    {ok, #{ <<"id">> := Id } } -> { ok, Id };
     Error -> Error
   end.
 

--- a/src/clc_v2_authentication.erl
+++ b/src/clc_v2_authentication.erl
@@ -9,7 +9,7 @@
 -spec login( Username::string(), Password::string() ) -> map().
 login( Username, Password ) ->
   Body = #{username => Username, password => Password},
-  clc_v2_http_client:post( ["authentication", "login"], Body ).
+  clc_v2_http_client:post( undefined, ["authentication", "login"], Body ).
 
 -spec account_alias( UserInfo::clc_v2_auth:user_info() ) -> string().
 account_alias( #{ <<"accountAlias">> := Alias } ) ->

--- a/src/clc_v2_datacenters.erl
+++ b/src/clc_v2_datacenters.erl
@@ -8,15 +8,12 @@
 
 -spec get( AuthRef::clc_v2_auth:auth_ref() ) -> map().
 get( AuthRef ) ->
-  { ok, Datacenters } = clc_v2_http_client:get( AuthRef, ["datacenters", account_alias] ),
-  Datacenters.
+  clc_v2_http_client:get( AuthRef, ["datacenters", account_alias] ).
 
 -spec get( AuthRef::clc_v2_auth:auth_ref(), DatacenterId::binary() ) -> map().
 get( AuthRef, DatacenterId ) ->
-  { ok, Datacenter } = clc_v2_http_client:get( AuthRef, ["datacenters", account_alias, binary_to_list( DatacenterId )]),
-  Datacenter.
+  clc_v2_http_client:get( AuthRef, ["datacenters", account_alias, binary_to_list( DatacenterId )]).
 
 -spec capabilities( AuthRef::clc_v2_auth:auth_ref(), DatacenterId::binary() ) -> map().
 capabilities( AuthRef, DatacenterId ) ->
-  { ok, Datacenter } = clc_v2_http_client:get( AuthRef, ["datacenters", account_alias, binary_to_list( DatacenterId ), "deploymentCapabilities"]),
-  Datacenter.
+  clc_v2_http_client:get( AuthRef, ["datacenters", account_alias, binary_to_list( DatacenterId ), "deploymentCapabilities"]).

--- a/src/clc_v2_http_client.erl
+++ b/src/clc_v2_http_client.erl
@@ -2,9 +2,12 @@
 
 -export([
   get/2,
-  post/3
+  post/3,
+  put/3
   ]).
 
+-define(PAYLOAD_HEADERS(), [ {"Content-Type","application/json"},
+                              {"Accept", "application/json"} ] ).
 -type route_token() :: account_alias.
 
 -spec get( AuthRef::clc_v2_auth:auth_ref(), Route::[string() | route_token()] ) -> { ok, map() } | { error, term() }.
@@ -14,9 +17,11 @@ get( AuthRef, Route ) ->
 
 -spec post( AuthRef::clc_v2_auth:auth_ref(), Route::[string() | route_token()], Body::string() | binary() ) -> { ok, map() } | { error, term() }.
 post( AuthRef, Route, Body ) ->
-  Headers = [ {"Content-Type","application/json"},
-              {"Accept", "application/json"} ],
-  send_req( AuthRef, Route, Headers, post, jiffy:encode(Body)).
+  send_req( AuthRef, Route, ?PAYLOAD_HEADERS(), post, jiffy:encode(Body)).
+
+-spec put( AuthRef::clc_v2_auth:auth_ref(), Route::[string() | route_token()], Body::string() | binary() ) -> { ok, map() } | { error, term() }.
+put( AuthRef, Route, Body ) ->
+  send_req( AuthRef, Route, ?PAYLOAD_HEADERS(), put, jiffy:encode(Body)).
 
 send_req( undefined, Route, Headers, Method, Body ) ->
   Url = build_url(#{}, Route, api_base()),

--- a/src/clc_v2_http_client.erl
+++ b/src/clc_v2_http_client.erl
@@ -26,7 +26,7 @@ put( AuthRef, Route, Body ) ->
 
 -spec delete( AuthRef::clc_v2_auth:auth_ref(), Route::[string() | route_token()] ) -> ok | { error, term() }.
 delete( AuthRef, Route ) ->
-  send_req( AuthRef, Route, [], delete, undefined).
+  send_req( AuthRef, Route, [], delete, []).
 
 send_req( undefined, Route, Headers, Method, Body ) ->
   Url = build_url(#{}, Route, api_base()),
@@ -38,13 +38,9 @@ send_req( AuthRef, Route, Headers, Method, Body ) ->
   Url = build_url( UserInfo, Route, api_base() ),
   send_req1( Url, Headers1, Method, Body ).
 
-send_req1( Url, Headers, delete, _ ) ->
-  case ibrowse:send_req( Url, Headers, delete ) of
-    {ok, "204", _, ResponseBody} -> ok;
-    {ok, Code, _, _} -> { error, "unexpected status code: " ++ Code }
-  end;
 send_req1( Url, Headers, Method, Body ) ->
   case ibrowse:send_req( Url, Headers, Method, Body ) of
+    {ok, "204", _, _} -> ok;
     {ok, "200", _, ResponseBody} -> {ok, jiffy:decode( ResponseBody, [return_maps] )};
     {ok, Code, _, _} -> { error, "unexpected status code: " ++ Code }
   end.

--- a/src/clc_v2_http_client.erl
+++ b/src/clc_v2_http_client.erl
@@ -39,11 +39,15 @@ send_req( AuthRef, Route, Headers, Method, Body ) ->
   send_req1( Url, Headers1, Method, Body ).
 
 send_req1( Url, Headers, delete, _ ) ->
-  {ok, "204", _, ResponseBody} = ibrowse:send_req( Url, Headers, delete ),
-  ok;
+  case ibrowse:send_req( Url, Headers, delete ) of
+    {ok, "204", _, ResponseBody} -> ok;
+    {ok, Code, _, _} -> { error, "unexpected status code: " ++ Code }
+  end;
 send_req1( Url, Headers, Method, Body ) ->
-  {ok, "200", _, ResponseBody} = ibrowse:send_req( Url, Headers, Method, Body ),
-  {ok, jiffy:decode( ResponseBody, [return_maps] )}.
+  case ibrowse:send_req( Url, Headers, Method, Body ) of
+    {ok, "200", _, ResponseBody} -> {ok, jiffy:decode( ResponseBody, [return_maps] )};
+    {ok, Code, _, _} -> { error, "unexpected status code: " ++ Code }
+  end.
 
 build_url(UserInfo, [H | Tail], Acc) when is_list(H)->
   build_url(UserInfo, Tail, Acc ++ "/" ++ H);

--- a/src/clc_v2_http_client.erl
+++ b/src/clc_v2_http_client.erl
@@ -3,7 +3,8 @@
 -export([
   get/2,
   post/3,
-  put/3
+  put/3,
+  delete/2
   ]).
 
 -define(PAYLOAD_HEADERS(), [ {"Content-Type","application/json"},
@@ -23,6 +24,10 @@ post( AuthRef, Route, Body ) ->
 put( AuthRef, Route, Body ) ->
   send_req( AuthRef, Route, ?PAYLOAD_HEADERS(), put, jiffy:encode(Body)).
 
+-spec delete( AuthRef::clc_v2_auth:auth_ref(), Route::[string() | route_token()] ) -> ok | { error, term() }.
+delete( AuthRef, Route ) ->
+  send_req( AuthRef, Route, [], delete, undefined).
+
 send_req( undefined, Route, Headers, Method, Body ) ->
   Url = build_url(#{}, Route, api_base()),
   send_req1( Url, Headers, Method, Body );
@@ -33,6 +38,9 @@ send_req( AuthRef, Route, Headers, Method, Body ) ->
   Url = build_url( UserInfo, Route, api_base() ),
   send_req1( Url, Headers1, Method, Body ).
 
+send_req1( Url, Headers, delete, _ ) ->
+  {ok, "204", _, ResponseBody} = ibrowse:send_req( Url, Headers, delete ),
+  ok;
 send_req1( Url, Headers, Method, Body ) ->
   {ok, "200", _, ResponseBody} = ibrowse:send_req( Url, Headers, Method, Body ),
   {ok, jiffy:decode( ResponseBody, [return_maps] )}.

--- a/test/clc_v2_alert_policies_tests.erl
+++ b/test/clc_v2_alert_policies_tests.erl
@@ -7,16 +7,18 @@ setup() ->
   ?meck( clc_v2_http_client, [non_strict]).
 
 get_calls_http_client_get() ->
-  ?stub( clc_v2_http_client, get, 2, { ok, data1 }),
+  Expected = { ok, data1 },
+  ?stub( clc_v2_http_client, get, 2, Expected),
 
-  ?assertEqual( data1, clc_v2_alert_policies:get( auth_ref1 ) ),
+  ?assertEqual( Expected, clc_v2_alert_policies:get( auth_ref1 ) ),
 
   ?called( clc_v2_http_client, get, [auth_ref1, ["alertPolicies", account_alias]] ).
 
 get_id_calls_http_client_get() ->
-  ?stub( clc_v2_http_client, get, 2, { ok, data1 }),
+  Expected = { ok, data1 },
+  ?stub( clc_v2_http_client, get, 2, Expected ),
 
-  ?assertEqual( data1, clc_v2_alert_policies:get( auth_ref1, <<"id1">> ) ),
+  ?assertEqual( Expected, clc_v2_alert_policies:get( auth_ref1, <<"id1">> ) ),
 
   ?called( clc_v2_http_client, get, [auth_ref1, ["alertPolicies", account_alias, "id1"]] ).
 
@@ -54,7 +56,7 @@ create_returns_expected_value() ->
 
   Actual = clc_v2_alert_policies:create( auth_ref1, ?EMPTY_POLICY() ),
 
-  ?assertEqual(Expected, Actual).
+  ?assertEqual({ ok, Expected }, Actual).
 
 create_returns_error_on_error() ->
   Error = { error, "Reason" },

--- a/test/clc_v2_alert_policies_tests.erl
+++ b/test/clc_v2_alert_policies_tests.erl
@@ -89,14 +89,14 @@ update_returns_expected_value() ->
 
   Actual = clc_v2_alert_policies:update( auth_ref1, ?EMPTY_POLICY(), <<>> ),
 
-  ?assertEqual(result1, Actual).
+  ?assertEqual(ok, Actual).
 
 delete_returns_expected_value() ->
   ?stub( clc_v2_http_client, delete, 2, result1 ),
 
   Actual = clc_v2_alert_policies:delete( auth_ref1, <<"id1">>),
 
-  ?assertEqual( result1, Actual ).
+  ?assertEqual( ok, Actual ).
 
 delete_calls_http_client_post_with_expected_route() ->
   ?stub( clc_v2_http_client, delete, 2, result1 ),

--- a/test/clc_v2_alert_policies_tests.erl
+++ b/test/clc_v2_alert_policies_tests.erl
@@ -95,18 +95,34 @@ update_calls_http_client_post_with_expected_body() ->
                ?capture(clc_v2_http_client, put, 3, 3)).
 
 update_returns_expected_value() ->
-  ?stub( clc_v2_http_client, put, 3, result1 ),
+  ?stub( clc_v2_http_client, put, 3, { ok, result1 }),
 
   Actual = clc_v2_alert_policies:update( auth_ref1, ?EMPTY_POLICY(), <<>> ),
 
   ?assertEqual(ok, Actual).
 
+update_returns_error_on_error() ->
+  Expected = { error, "Reason" },
+  ?stub( clc_v2_http_client, put, 3, Expected ),
+
+  Actual = clc_v2_alert_policies:update( auth_ref1, ?EMPTY_POLICY(), <<>> ),
+
+  ?assertEqual( Expected, Actual ).
+
 delete_returns_expected_value() ->
-  ?stub( clc_v2_http_client, delete, 2, result1 ),
+  ?stub( clc_v2_http_client, delete, 2, { ok, result1 }),
 
   Actual = clc_v2_alert_policies:delete( auth_ref1, <<"id1">>),
 
   ?assertEqual( ok, Actual ).
+
+delete_returns_error_on_error() ->
+  Expected = { error, "Reason" },
+  ?stub( clc_v2_http_client, delete, 2, Expected ),
+
+  Actual = clc_v2_alert_policies:delete( auth_ref1, <<"id1">>),
+
+  ?assertEqual( Expected, Actual ).
 
 delete_calls_http_client_post_with_expected_route() ->
   ?stub( clc_v2_http_client, delete, 2, result1 ),

--- a/test/clc_v2_alert_policies_tests.erl
+++ b/test/clc_v2_alert_policies_tests.erl
@@ -61,7 +61,7 @@ update_calls_http_client_post_with_expected_route() ->
 
   clc_v2_alert_policies:update( auth_ref1, ?EMPTY_POLICY(), <<"id1">> ),
 
-  ?called( clc_v2_http_client, put, [auth_ref1, ["alertPolicies", account_alias, <<"id1">>], ?any] ).
+  ?called( clc_v2_http_client, put, [auth_ref1, ["alertPolicies", account_alias, "id1"], ?any] ).
 
 update_calls_http_client_post_with_expected_body() ->
   ?stub( clc_v2_http_client, put, 3, result1 ),

--- a/test/clc_v2_alert_policies_tests.erl
+++ b/test/clc_v2_alert_policies_tests.erl
@@ -90,3 +90,17 @@ update_returns_expected_value() ->
   Actual = clc_v2_alert_policies:update( auth_ref1, ?EMPTY_POLICY(), <<>> ),
 
   ?assertEqual(result1, Actual).
+
+delete_returns_expected_value() ->
+  ?stub( clc_v2_http_client, delete, 2, result1 ),
+
+  Actual = clc_v2_alert_policies:delete( auth_ref1, <<"id1">>),
+
+  ?assertEqual( result1, Actual ).
+
+delete_calls_http_client_post_with_expected_route() ->
+  ?stub( clc_v2_http_client, delete, 2, result1 ),
+
+  clc_v2_alert_policies:delete( auth_ref1, <<"id1">> ),
+
+  ?called( clc_v2_http_client, delete, [auth_ref1, ["alertPolicies", account_alias, "id1"] ] ).

--- a/test/clc_v2_alert_policies_tests.erl
+++ b/test/clc_v2_alert_policies_tests.erl
@@ -56,6 +56,14 @@ create_returns_expected_value() ->
 
   ?assertEqual(Expected, Actual).
 
+create_returns_error_on_error() ->
+  Error = { error, "Reason" },
+  ?stub( clc_v2_http_client, post, 3, Error),
+
+  Actual = clc_v2_alert_policies:create( auth_ref1, ?EMPTY_POLICY() ),
+
+  ?assertEqual(Error, Actual).
+
 update_calls_http_client_post_with_expected_route() ->
   ?stub( clc_v2_http_client, put, 3, result1 ),
 

--- a/test/clc_v2_alert_policies_tests.erl
+++ b/test/clc_v2_alert_policies_tests.erl
@@ -1,5 +1,6 @@
 -module( clc_v2_alert_policies_tests ).
 -include( "test_fixture.hrl" ).
+-define(EMPTY_POLICY(), #{ name => <<>>, email_recipients => [], triggers => []}).
 
 %https://www.centurylinkcloud.com/api-docs/v2/#alert-policies-get-alert-policies
 setup() ->
@@ -22,7 +23,7 @@ get_id_calls_http_client_get() ->
 create_calls_http_client_post_with_expected_route() ->
   ?stub( clc_v2_http_client, post, 3, { ok, #{ <<"id">> => <<"id1">> } }),
 
-  clc_v2_alert_policies:create( auth_ref1, #{ name => <<>>, email_recipients => [], triggers => []} ),
+  clc_v2_alert_policies:create( auth_ref1, ?EMPTY_POLICY() ),
 
   ?called( clc_v2_http_client, post, [auth_ref1, ["alertPolicies", account_alias], ?any] ).
 
@@ -51,6 +52,41 @@ create_returns_expected_value() ->
   Expected = <<"id1">>,
   ?stub( clc_v2_http_client, post, 3, { ok, #{ <<"id">> => Expected } }),
 
-  Actual = clc_v2_alert_policies:create( auth_ref1, #{ name => <<>>, email_recipients => [], triggers => []} ),
+  Actual = clc_v2_alert_policies:create( auth_ref1, ?EMPTY_POLICY() ),
 
   ?assertEqual(Expected, Actual).
+
+update_calls_http_client_post_with_expected_route() ->
+  ?stub( clc_v2_http_client, put, 3, result1 ),
+
+  clc_v2_alert_policies:update( auth_ref1, ?EMPTY_POLICY(), <<"id1">> ),
+
+  ?called( clc_v2_http_client, put, [auth_ref1, ["alertPolicies", account_alias, <<"id1">>], ?any] ).
+
+update_calls_http_client_post_with_expected_body() ->
+  ?stub( clc_v2_http_client, put, 3, result1 ),
+
+  clc_v2_alert_policies:update( auth_ref1,
+                                #{ name => <<"p1">>,
+                                   email_recipients => [<<"r1@host.com">>, <<"r2@host.com">>],
+                                   triggers =>
+                                     [ #{ metric => metric1, duration => <<"00:00:01">>, threshold => 0.01 },
+                                       #{ metric => metric2, duration => <<"01:01:01">>, threshold => 99.99 } ]
+                                }, <<>>),
+
+  ?assertEqual( #{ name => <<"p1">>,
+                   actions =>
+                   [#{ action => email,
+                       settings => #{ recipients => [<<"r1@host.com">>, <<"r2@host.com">>] } }],
+                  triggers =>
+                    [#{ metric => metric1, duration => <<"00:00:01">>, threshold => 0.01 },
+                     #{ metric => metric2, duration => <<"01:01:01">>, threshold => 99.99 } ]
+                },
+               ?capture(clc_v2_http_client, put, 3, 3)).
+
+update_returns_expected_value() ->
+  ?stub( clc_v2_http_client, put, 3, result1 ),
+
+  Actual = clc_v2_alert_policies:update( auth_ref1, ?EMPTY_POLICY(), <<>> ),
+
+  ?assertEqual(result1, Actual).

--- a/test/clc_v2_alert_policies_tests.erl
+++ b/test/clc_v2_alert_policies_tests.erl
@@ -9,3 +9,11 @@ get_calls_http_client_get() ->
   ?assertEqual( data1, clc_v2_alert_policies:get( auth_ref1 ) ),
 
   ?called( clc_v2_http_client, get, [auth_ref1, ["alertPolicies", account_alias]] ).
+
+get_id_calls_http_client_get() ->
+  ?meck( clc_v2_http_client, [non_strict]),
+  ?stub( clc_v2_http_client, get, 2, { ok, data1 }),
+
+  ?assertEqual( data1, clc_v2_alert_policies:get( auth_ref1, <<"id1">> ) ),
+
+  ?called( clc_v2_http_client, get, [auth_ref1, ["alertPolicies", account_alias, "id1"]] ).

--- a/test/clc_v2_alert_policies_tests.erl
+++ b/test/clc_v2_alert_policies_tests.erl
@@ -2,8 +2,10 @@
 -include( "test_fixture.hrl" ).
 
 %https://www.centurylinkcloud.com/api-docs/v2/#alert-policies-get-alert-policies
+setup() ->
+  ?meck( clc_v2_http_client, [non_strict]).
+
 get_calls_http_client_get() ->
-  ?meck( clc_v2_http_client, [non_strict]),
   ?stub( clc_v2_http_client, get, 2, { ok, data1 }),
 
   ?assertEqual( data1, clc_v2_alert_policies:get( auth_ref1 ) ),
@@ -11,9 +13,44 @@ get_calls_http_client_get() ->
   ?called( clc_v2_http_client, get, [auth_ref1, ["alertPolicies", account_alias]] ).
 
 get_id_calls_http_client_get() ->
-  ?meck( clc_v2_http_client, [non_strict]),
   ?stub( clc_v2_http_client, get, 2, { ok, data1 }),
 
   ?assertEqual( data1, clc_v2_alert_policies:get( auth_ref1, <<"id1">> ) ),
 
   ?called( clc_v2_http_client, get, [auth_ref1, ["alertPolicies", account_alias, "id1"]] ).
+
+create_calls_http_client_post_with_expected_route() ->
+  ?stub( clc_v2_http_client, post, 3, { ok, #{ <<"id">> => <<"id1">> } }),
+
+  clc_v2_alert_policies:create( auth_ref1, #{ name => <<>>, email_recipients => [], triggers => []} ),
+
+  ?called( clc_v2_http_client, post, [auth_ref1, ["alertPolicies", account_alias], ?any] ).
+
+create_calls_http_client_post_with_expected_body() ->
+  ?stub( clc_v2_http_client, post, 3, { ok, #{ <<"id">> => <<"id1">> } }),
+
+  clc_v2_alert_policies:create( auth_ref1,
+                                #{ name => <<"p1">>,
+                                   email_recipients => [<<"r1@host.com">>, <<"r2@host.com">>],
+                                   triggers =>
+                                     [ #{ metric => metric1, duration => <<"00:00:01">>, threshold => 0.01 },
+                                       #{ metric => metric2, duration => <<"01:01:01">>, threshold => 99.99 } ]
+                                }),
+
+  ?assertEqual( #{ name => <<"p1">>,
+                   actions =>
+                   [#{ action => email,
+                       settings => #{ recipients => [<<"r1@host.com">>, <<"r2@host.com">>] } }],
+                  triggers =>
+                    [#{ metric => metric1, duration => <<"00:00:01">>, threshold => 0.01 },
+                     #{ metric => metric2, duration => <<"01:01:01">>, threshold => 99.99 } ]
+                },
+               ?capture(clc_v2_http_client, post, 3, 3)).
+
+create_returns_expected_value() ->
+  Expected = <<"id1">>,
+  ?stub( clc_v2_http_client, post, 3, { ok, #{ <<"id">> => Expected } }),
+
+  Actual = clc_v2_alert_policies:create( auth_ref1, #{ name => <<>>, email_recipients => [], triggers => []} ),
+
+  ?assertEqual(Expected, Actual).

--- a/test/clc_v2_authentication_tests.erl
+++ b/test/clc_v2_authentication_tests.erl
@@ -3,17 +3,17 @@
 
 setup() ->
   ?meck( clc_v2_http_client, [non_strict] ),
-  ?stub( clc_v2_http_client, post, 2, user_info1 ).
+  ?stub( clc_v2_http_client, post, 3, user_info1 ).
 
 login_calls_http_client_post_with_authentication_route() ->
   ?assertEqual( user_info1, clc_v2_authentication:login( username1, password1 )),
 
-  ?called( clc_v2_http_client, post, [["authentication","login"], ?any]).
+  ?called( clc_v2_http_client, post, [undefined, ["authentication","login"], ?any]).
 
 login_wraps_username_and_password_in_json_body() ->
   clc_v2_authentication:login( username1, password1 ),
 
-  ?called( clc_v2_http_client, post, [?any, #{username => username1, password => password1}]).
+  ?called( clc_v2_http_client, post, [?any, ?any, #{username => username1, password => password1}]).
 
 login_returns_result_of_clc_v2_authentication_login() ->
   ?assertEqual( user_info1, clc_v2_authentication:login( username1, password1 )).

--- a/test/clc_v2_datacenters_tests.erl
+++ b/test/clc_v2_datacenters_tests.erl
@@ -3,25 +3,28 @@
 
 % https://www.centurylinkcloud.com/api-docs/v2/#data-centers
 get_calls_http_client_get() ->
+  Expected = { ok, data1 },
   ?meck( clc_v2_http_client, [non_strict]),
-  ?stub( clc_v2_http_client, get, 2, { ok, data1 }),
+  ?stub( clc_v2_http_client, get, 2, Expected ),
 
-  ?assertEqual( data1, clc_v2_datacenters:get( auth_ref1 ) ),
+  ?assertEqual( Expected, clc_v2_datacenters:get( auth_ref1 ) ),
 
   ?called( clc_v2_http_client, get, [auth_ref1, ["datacenters", account_alias]] ).
 
 get_with_datacenter_id_converts_datacenter_id_to_a_list_and_calls_http_client_get() ->
+  Expected = { ok, data1 },
   ?meck( clc_v2_http_client, [non_strict]),
-  ?stub( clc_v2_http_client, get, 2, { ok, data1 }),
+  ?stub( clc_v2_http_client, get, 2, Expected ),
 
-  ?assertEqual( data1, clc_v2_datacenters:get( auth_ref1, <<"dc1">> ) ),
+  ?assertEqual( Expected, clc_v2_datacenters:get( auth_ref1, <<"dc1">> ) ),
 
   ?called( clc_v2_http_client, get, [auth_ref1, ["datacenters", account_alias, "dc1"]] ).
 
 capabilities_with_datacenter_id_converts_datacenter_id_to_a_list_and_calls_http_client_get() ->
+  Expected = { ok, data1 },
   ?meck( clc_v2_http_client, [non_strict]),
-  ?stub( clc_v2_http_client, get, 2, { ok, data1 }),
+  ?stub( clc_v2_http_client, get, 2, Expected ),
 
-  ?assertEqual( data1, clc_v2_datacenters:capabilities( auth_ref1, <<"dc1">> ) ),
+  ?assertEqual( Expected, clc_v2_datacenters:capabilities( auth_ref1, <<"dc1">> ) ),
 
   ?called( clc_v2_http_client, get, [auth_ref1, ["datacenters", account_alias, "dc1","deploymentCapabilities"]] ).

--- a/test/clc_v2_http_client_tests.erl
+++ b/test/clc_v2_http_client_tests.erl
@@ -53,6 +53,11 @@ get_decodes_response_body() ->
 
   ?assertMatch({ ok, #{ <<"key1">> := <<"value1">> }}, clc_v2_http_client:get( auth_ref1, ["route1"])).
 
+get_returns_error_on_not2xx() ->
+  ?stub( ibrowse, send_req, 4, {ok, "not2xx", [], <<>> }),
+
+  ?assertMatch({ error, "unexpected status code: not2xx" }, clc_v2_http_client:get( auth_ref1, ["route1"])).
+
 post_appends_multiple_route_directories_to_api_base_and_posts() ->
   clc_v2_http_client:post(  auth_ref1, ["route1", "route2"], #{ key1 => "value1", key2 => "value2" }),
 
@@ -69,7 +74,6 @@ post_encodes_body_as_json() ->
   ExpectedJson = <<"{\"key2\":\"value2\",\"key1\":\"value1\"}">>,
 
   ?called( ibrowse, send_req, [?any, ?any, ?any, ExpectedJson] ).
-
 
 post_sends_authorization_header_when_auth_ref_supplied() ->
   clc_v2_http_client:post( auth_ref1, ["route1"], #{} ),
@@ -102,6 +106,11 @@ post_decodes_response_body() ->
   ?stub( ibrowse, send_req, 4, {ok, "200", [], ResponseBody }),
 
   ?assertMatch({ok, #{ <<"key1">> := <<"value1">> }}, clc_v2_http_client:post( auth_ref1, ["route1"], #{})).
+
+post_returns_error_on_not2xx() ->
+  ?stub( ibrowse, send_req, 4, {ok, "not2xx", [], <<>> }),
+
+  ?assertMatch({ error, "unexpected status code: not2xx" }, clc_v2_http_client:post( auth_ref1, ["route1"], #{})).
 
 put_appends_multiple_route_directories_to_api_base_and_posts() ->
   clc_v2_http_client:put(  auth_ref1, ["route1", "route2"], #{ key1 => "value1", key2 => "value2" }),
@@ -145,6 +154,11 @@ put_decodes_response_body() ->
 
   ?assertMatch({ok, #{ <<"key1">> := <<"value1">> }}, clc_v2_http_client:put( auth_ref1, ["route1"], #{})).
 
+put_returns_error_on_not2xx() ->
+  ?stub( ibrowse, send_req, 4, {ok, "not2xx", [], <<>> }),
+
+  ?assertMatch({ error, "unexpected status code: not2xx" }, clc_v2_http_client:put( auth_ref1, ["route1"], #{})).
+
 delete_appends_multiple_route_directories_to_api_base_and_posts() ->
   ?stub( ibrowse, send_req, 3, {ok, "204", [], ignored1} ),
 
@@ -173,3 +187,8 @@ delete_returns_ok_on_success() ->
   ?stub( ibrowse, send_req, 3, {ok, "204", [], ignored1} ),
 
   ?assertEqual( ok, clc_v2_http_client:delete(auth_ref1, ["route1"]) ).
+
+delete_returns_error_on_not2xx() ->
+  ?stub( ibrowse, send_req, 3, {ok, "not2xx", [], <<>> }),
+
+  ?assertMatch({ error, "unexpected status code: not2xx" }, clc_v2_http_client:delete( auth_ref1, ["route1"])).

--- a/test/clc_v2_http_client_tests.erl
+++ b/test/clc_v2_http_client_tests.erl
@@ -54,18 +54,45 @@ get_decodes_response_body() ->
   ?assertMatch({ ok, #{ <<"key1">> := <<"value1">> }}, clc_v2_http_client:get( auth_ref1, ["route1"])).
 
 post_appends_multiple_route_directories_to_api_base_and_posts() ->
-  clc_v2_http_client:post(  ["route1", "route2"], #{ key1 => "value1", key2 => "value2" }),
+  clc_v2_http_client:post(  auth_ref1, ["route1", "route2"], #{ key1 => "value1", key2 => "value2" }),
 
   ?called( ibrowse, send_req, ["http://api.base/route1/route2", ?any, post, ?any] ).
 
+post_calls_authentication_lens_to_resolve_atom_route_directories() ->
+  clc_v2_http_client:post( auth_ref1, ["route1", route_lens, "route3"], #{} ),
+
+  ?called( clc_v2_authentication, route_lens, [user_info1] ),
+  ?called( ibrowse, send_req, ["http://api.base/route1/lens_result1/route3", ?any, post, ?any ] ).
+
 post_encodes_body_as_json() ->
-  clc_v2_http_client:post(  ["route1"], #{ key1 => <<"value1">>, key2 => <<"value2">> }),
+  clc_v2_http_client:post( auth_ref1, ["route1"], #{ key1 => <<"value1">>, key2 => <<"value2">> }),
   ExpectedJson = <<"{\"key2\":\"value2\",\"key1\":\"value1\"}">>,
 
   ?called( ibrowse, send_req, [?any, ?any, ?any, ExpectedJson] ).
 
+
+post_sends_authorization_header_when_auth_ref_supplied() ->
+  clc_v2_http_client:post( auth_ref1, ["route1"], #{} ),
+
+  ?called( clc_v2_authentication, bearer_token, [user_info1] ),
+  Headers = ?capture( ibrowse, send_req, 4, 2 ),
+  ?assert(lists:member( {"Authorization", "Bearer LONG_BEARER_TOKEN"}, Headers )).
+
+post_omits_authorization_header_when_auth_ref_undefined() ->
+  clc_v2_http_client:post( undefined, ["route1"], #{} ),
+
+  ?not_called( clc_v2_authentication, bearer_token, [user_info1] ),
+  Headers = ?capture( ibrowse, send_req, 4, 2 ),
+  ?assertNot(lists:member( {"Authorization", "Bearer LONG_BEARER_TOKEN"}, Headers )).
+
+post_sends_accept_header() ->
+  clc_v2_http_client:post( auth_ref1, ["route1"], #{} ),
+
+  Headers = ?capture( ibrowse, send_req, 4, 2 ),
+  ?assert(lists:member( {"Accept", "application/json"}, Headers )).
+
 post_sends_content_type_header() ->
-  clc_v2_http_client:post(  ["route1"], #{ key1 => <<"value1">>, key2 => <<"value2">> }),
+  clc_v2_http_client:post(  auth_ref1, ["route1"], #{ key1 => <<"value1">>, key2 => <<"value2">> }),
 
   Headers = ?capture( ibrowse, send_req, 4, 2),
   ?assert(lists:member( {"Content-Type", "application/json"}, Headers )).
@@ -74,4 +101,4 @@ post_decodes_response_body() ->
   ResponseBody = <<"{\"key1\":\"value1\"}">>,
   ?stub( ibrowse, send_req, 4, {ok, "200", [], ResponseBody }),
 
-  ?assertMatch({ok, #{ <<"key1">> := <<"value1">> }}, clc_v2_http_client:post( ["route1"], #{})).
+  ?assertMatch({ok, #{ <<"key1">> := <<"value1">> }}, clc_v2_http_client:post( auth_ref1, ["route1"], #{})).

--- a/test/clc_v2_http_client_tests.erl
+++ b/test/clc_v2_http_client_tests.erl
@@ -160,35 +160,35 @@ put_returns_error_on_not2xx() ->
   ?assertMatch({ error, "unexpected status code: not2xx" }, clc_v2_http_client:put( auth_ref1, ["route1"], #{})).
 
 delete_appends_multiple_route_directories_to_api_base_and_posts() ->
-  ?stub( ibrowse, send_req, 3, {ok, "204", [], ignored1} ),
+  ?stub( ibrowse, send_req, 4, {ok, "204", [], ignored1} ),
 
   clc_v2_http_client:delete( auth_ref1, ["route1", "route2"] ),
 
-  ?called( ibrowse, send_req, ["http://api.base/route1/route2", ?any, delete] ).
+  ?called( ibrowse, send_req, ["http://api.base/route1/route2", ?any, delete, []] ).
 
 delete_calls_authentication_lens_to_resolve_atom_route_directories() ->
-  ?stub( ibrowse, send_req, 3, {ok, "204", [], ignored1} ),
+  ?stub( ibrowse, send_req, 4, {ok, "204", [], ignored1} ),
 
   clc_v2_http_client:delete( auth_ref1, ["route1", route_lens, "route3"] ),
 
   ?called( clc_v2_authentication, route_lens, [user_info1] ),
-  ?called( ibrowse, send_req, ["http://api.base/route1/lens_result1/route3", ?any, delete ] ).
+  ?called( ibrowse, send_req, ["http://api.base/route1/lens_result1/route3", ?any, delete, [] ] ).
 
 delete_sends_authorization_header() ->
-  ?stub( ibrowse, send_req, 3, {ok, "204", [], ignored1} ),
+  ?stub( ibrowse, send_req, 4, {ok, "204", [], ignored1} ),
 
   clc_v2_http_client:delete( auth_ref1, ["route1"] ),
 
   ?called( clc_v2_authentication, bearer_token, [user_info1] ),
-  Headers = ?capture( ibrowse, send_req, 3, 2 ),
+  Headers = ?capture( ibrowse, send_req, 4, 2 ),
   ?assert(lists:member( {"Authorization", "Bearer LONG_BEARER_TOKEN"}, Headers )).
 
 delete_returns_ok_on_success() ->
-  ?stub( ibrowse, send_req, 3, {ok, "204", [], ignored1} ),
+  ?stub( ibrowse, send_req, 4, {ok, "204", [], ignored1} ),
 
   ?assertEqual( ok, clc_v2_http_client:delete(auth_ref1, ["route1"]) ).
 
 delete_returns_error_on_not2xx() ->
-  ?stub( ibrowse, send_req, 3, {ok, "not2xx", [], <<>> }),
+  ?stub( ibrowse, send_req, 4, {ok, "not2xx", [], <<>> }),
 
   ?assertMatch({ error, "unexpected status code: not2xx" }, clc_v2_http_client:delete( auth_ref1, ["route1"])).

--- a/test/clc_v2_http_client_tests.erl
+++ b/test/clc_v2_http_client_tests.erl
@@ -120,7 +120,6 @@ put_encodes_body_as_json() ->
 
   ?called( ibrowse, send_req, [?any, ?any, ?any, ExpectedJson] ).
 
-
 put_sends_authorization_header() ->
   clc_v2_http_client:put( auth_ref1, ["route1"], #{} ),
 
@@ -145,3 +144,32 @@ put_decodes_response_body() ->
   ?stub( ibrowse, send_req, 4, {ok, "200", [], ResponseBody }),
 
   ?assertMatch({ok, #{ <<"key1">> := <<"value1">> }}, clc_v2_http_client:put( auth_ref1, ["route1"], #{})).
+
+delete_appends_multiple_route_directories_to_api_base_and_posts() ->
+  ?stub( ibrowse, send_req, 3, {ok, "204", [], ignored1} ),
+
+  clc_v2_http_client:delete( auth_ref1, ["route1", "route2"] ),
+
+  ?called( ibrowse, send_req, ["http://api.base/route1/route2", ?any, delete] ).
+
+delete_calls_authentication_lens_to_resolve_atom_route_directories() ->
+  ?stub( ibrowse, send_req, 3, {ok, "204", [], ignored1} ),
+
+  clc_v2_http_client:delete( auth_ref1, ["route1", route_lens, "route3"] ),
+
+  ?called( clc_v2_authentication, route_lens, [user_info1] ),
+  ?called( ibrowse, send_req, ["http://api.base/route1/lens_result1/route3", ?any, delete ] ).
+
+delete_sends_authorization_header() ->
+  ?stub( ibrowse, send_req, 3, {ok, "204", [], ignored1} ),
+
+  clc_v2_http_client:delete( auth_ref1, ["route1"] ),
+
+  ?called( clc_v2_authentication, bearer_token, [user_info1] ),
+  Headers = ?capture( ibrowse, send_req, 3, 2 ),
+  ?assert(lists:member( {"Authorization", "Bearer LONG_BEARER_TOKEN"}, Headers )).
+
+delete_returns_ok_on_success() ->
+  ?stub( ibrowse, send_req, 3, {ok, "204", [], ignored1} ),
+
+  ?assertEqual( ok, clc_v2_http_client:delete(auth_ref1, ["route1"]) ).

--- a/test/clc_v2_tests.erl
+++ b/test/clc_v2_tests.erl
@@ -33,6 +33,14 @@ clc_v2_alert_policies_delegates_to_alert_policies_get() ->
 
   ?called(clc_v2_alert_policies, get, [auth_ref1]).
 
+clc_v2_alert_policy_delegates_to_alert_policies_get() ->
+  ?meck(clc_v2_alert_policies, [non_strict]),
+  ?stub(clc_v2_alert_policies, get, 2, alert_policy1),
+
+  ?assertEqual(alert_policy1, clc_v2:alert_policy(auth_ref1, id1)),
+
+  ?called(clc_v2_alert_policies, get, [auth_ref1, id1]).
+
 login_creates_new_auth_worker_under_auth_supervisor() ->
   ?meck( clc_v2_auth_sup, [non_strict] ),
   ?stub( clc_v2_auth_sup, create_worker, 2, {ok, authref1}),

--- a/test/clc_v2_tests.erl
+++ b/test/clc_v2_tests.erl
@@ -66,9 +66,10 @@ clc_v2_delete_alert_policy_delegates_to_alert_policies_delete() ->
   ?called(clc_v2_alert_policies, delete, [auth_ref1, id1]).
 
 login_creates_new_auth_worker_under_auth_supervisor() ->
+  Expected = { ok, authref1 },
   ?meck( clc_v2_auth_sup, [non_strict] ),
-  ?stub( clc_v2_auth_sup, create_worker, 2, {ok, authref1}),
+  ?stub( clc_v2_auth_sup, create_worker, 2, Expected),
 
-  ?assertEqual( authref1, clc_v2:login( username1, password1 ) ),
+  ?assertEqual( Expected, clc_v2:login( username1, password1 ) ),
 
   ?called( clc_v2_auth_sup, create_worker, [username1, password1] ).

--- a/test/clc_v2_tests.erl
+++ b/test/clc_v2_tests.erl
@@ -57,6 +57,14 @@ clc_v2_update_alert_policy_delegates_to_alert_policies_update() ->
 
   ?called(clc_v2_alert_policies, update, [auth_ref1, spec1, id1]).
 
+clc_v2_delete_alert_policy_delegates_to_alert_policies_delete() ->
+  ?meck(clc_v2_alert_policies, [non_strict]),
+  ?stub(clc_v2_alert_policies, delete, 2, result1),
+
+  ?assertEqual(result1, clc_v2:delete_alert_policy(auth_ref1, id1)),
+
+  ?called(clc_v2_alert_policies, delete, [auth_ref1, id1]).
+
 login_creates_new_auth_worker_under_auth_supervisor() ->
   ?meck( clc_v2_auth_sup, [non_strict] ),
   ?stub( clc_v2_auth_sup, create_worker, 2, {ok, authref1}),

--- a/test/clc_v2_tests.erl
+++ b/test/clc_v2_tests.erl
@@ -41,6 +41,14 @@ clc_v2_alert_policy_delegates_to_alert_policies_get() ->
 
   ?called(clc_v2_alert_policies, get, [auth_ref1, id1]).
 
+clc_v2_create_alert_policy_delegates_to_alert_policies_create() ->
+  ?meck(clc_v2_alert_policies, [non_strict]),
+  ?stub(clc_v2_alert_policies, create, 2, id1),
+
+  ?assertEqual(id1, clc_v2:create_alert_policy(auth_ref1, spec1)),
+
+  ?called(clc_v2_alert_policies, create, [auth_ref1, spec1]).
+
 login_creates_new_auth_worker_under_auth_supervisor() ->
   ?meck( clc_v2_auth_sup, [non_strict] ),
   ?stub( clc_v2_auth_sup, create_worker, 2, {ok, authref1}),

--- a/test/clc_v2_tests.erl
+++ b/test/clc_v2_tests.erl
@@ -49,6 +49,14 @@ clc_v2_create_alert_policy_delegates_to_alert_policies_create() ->
 
   ?called(clc_v2_alert_policies, create, [auth_ref1, spec1]).
 
+clc_v2_update_alert_policy_delegates_to_alert_policies_update() ->
+  ?meck(clc_v2_alert_policies, [non_strict]),
+  ?stub(clc_v2_alert_policies, update, 3, result1),
+
+  ?assertEqual(result1, clc_v2:update_alert_policy(auth_ref1, spec1, id1)),
+
+  ?called(clc_v2_alert_policies, update, [auth_ref1, spec1, id1]).
+
 login_creates_new_auth_worker_under_auth_supervisor() ->
   ?meck( clc_v2_auth_sup, [non_strict] ),
   ?stub( clc_v2_auth_sup, create_worker, 2, {ok, authref1}),

--- a/uats/alert_policies_SUITE.erl
+++ b/uats/alert_policies_SUITE.erl
@@ -28,7 +28,7 @@ clc_v2_alerts_returns_expected_policies(Config) ->
   Expected = random_policies(),
   data_server:put(alert_policies, Expected),
 
-  Actual = clc_v2:alert_policies(proplists:get_value( auth_ref, Config )),
+  { ok, Actual } = clc_v2:alert_policies(proplists:get_value( auth_ref, Config )),
 
   assert:equal(Expected, Actual),
   ok.
@@ -38,7 +38,7 @@ clc_v2_alerts_returns_a_single_policy(Config) ->
   data_server:put(alert_policies, Id, Expected),
 
   AuthRef = proplists:get_value( auth_ref, Config ),
-  Actual = clc_v2:alert_policy(AuthRef, Id),
+  { ok, Actual } = clc_v2:alert_policy(AuthRef, Id),
 
   assert:equal(Expected, Actual),
   ok.
@@ -63,7 +63,7 @@ clc_v2_alerts_creates_expected_policy(Config) ->
 
 
   AuthRef = proplists:get_value( auth_ref, Config ),
-  Id = clc_v2:create_alert_policy(AuthRef, Spec),
+  { ok, Id } = clc_v2:create_alert_policy(AuthRef, Spec),
 
   assert:equal(Expected, data_server:get(alert_policies, Id)),
   ok.

--- a/uats/alert_policies_SUITE.erl
+++ b/uats/alert_policies_SUITE.erl
@@ -1,9 +1,11 @@
 -module(alert_policies_SUITE).
 -include("uat_helper.hrl").
 -export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
--export([clc_v2_alerts_returns_expected_policies/1]).
+-export([clc_v2_alerts_returns_expected_policies/1,
+         clc_v2_alerts_returns_a_single_policy/1]).
 
-all() -> [clc_v2_alerts_returns_expected_policies].
+all() -> [clc_v2_alerts_returns_expected_policies,
+          clc_v2_alerts_returns_a_single_policy].
 
 suite() ->
       [{timetrap,{minutes,1}}].
@@ -19,6 +21,16 @@ clc_v2_alerts_returns_expected_policies(Config) ->
   data_server:put(alert_policies, Expected),
 
   Actual = clc_v2:alert_policies(proplists:get_value( auth_ref, Config )),
+
+  assert:equal(Expected, Actual),
+  ok.
+
+clc_v2_alerts_returns_a_single_policy(Config) ->
+  Expected = #{<<"id">> := Id} = random_policy(),
+  data_server:put(alert_policies, Id, Expected),
+
+  AuthRef = proplists:get_value( auth_ref, Config ),
+  Actual = clc_v2:alert_policy(AuthRef, Id),
 
   assert:equal(Expected, Actual),
   ok.

--- a/uats/alert_policies_SUITE.erl
+++ b/uats/alert_policies_SUITE.erl
@@ -4,13 +4,15 @@
 -export([clc_v2_alerts_returns_expected_policies/1,
          clc_v2_alerts_returns_a_single_policy/1,
          clc_v2_alerts_creates_expected_policy/1,
-         clc_v2_alerts_updates_expected_policy/1
+         clc_v2_alerts_updates_expected_policy/1,
+         clc_v2_alerts_deletes_expected_policy/1
         ]).
 
 all() -> [clc_v2_alerts_returns_expected_policies,
           clc_v2_alerts_returns_a_single_policy,
           clc_v2_alerts_creates_expected_policy,
-          clc_v2_alerts_updates_expected_policy
+          clc_v2_alerts_updates_expected_policy,
+          clc_v2_alerts_deletes_expected_policy
          ].
 
 suite() ->
@@ -88,6 +90,15 @@ clc_v2_alerts_updates_expected_policy(Config) ->
   assert:equal(Expected, data_server:get(alert_policies, Id)),
   ok.
 
+
+clc_v2_alerts_deletes_expected_policy(Config) ->
+  Id = <<"123">>,
+
+  AuthRef = proplists:get_value( auth_ref, Config ),
+  clc_v2:delete_alert_policy(AuthRef, Id),
+
+  assert:equal(deleted, data_server:get(alert_policies, Id)),
+  ok.
 
 random_policies() ->
   Items = [random_policy(),

--- a/uats/alert_policies_SUITE.erl
+++ b/uats/alert_policies_SUITE.erl
@@ -81,7 +81,7 @@ clc_v2_alerts_updates_expected_policy(Config) ->
                   [#{ <<"metric">> => <<"cpu">>, <<"duration">> => <<"00:00:01">>, <<"threshold">> => 67.8 } ]
               },
 
-  Id = 123,
+  Id = <<"123">>,
   AuthRef = proplists:get_value( auth_ref, Config ),
   clc_v2:update_alert_policy(AuthRef, Spec, Id),
 

--- a/uats/alert_policies_SUITE.erl
+++ b/uats/alert_policies_SUITE.erl
@@ -85,7 +85,7 @@ clc_v2_alerts_updates_expected_policy(Config) ->
 
   Id = <<"123">>,
   AuthRef = proplists:get_value( auth_ref, Config ),
-  clc_v2:update_alert_policy(AuthRef, Spec, Id),
+  ok = clc_v2:update_alert_policy(AuthRef, Spec, Id),
 
   assert:equal(Expected, data_server:get(alert_policies, Id)),
   ok.
@@ -95,7 +95,7 @@ clc_v2_alerts_deletes_expected_policy(Config) ->
   Id = <<"123">>,
 
   AuthRef = proplists:get_value( auth_ref, Config ),
-  clc_v2:delete_alert_policy(AuthRef, Id),
+  ok = clc_v2:delete_alert_policy(AuthRef, Id),
 
   assert:equal(deleted, data_server:get(alert_policies, Id)),
   ok.

--- a/uats/alert_policies_SUITE.erl
+++ b/uats/alert_policies_SUITE.erl
@@ -3,12 +3,14 @@
 -export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
 -export([clc_v2_alerts_returns_expected_policies/1,
          clc_v2_alerts_returns_a_single_policy/1,
-         clc_v2_alerts_creates_expected_policy/1
+         clc_v2_alerts_creates_expected_policy/1,
+         clc_v2_alerts_updates_expected_policy/1
         ]).
 
 all() -> [clc_v2_alerts_returns_expected_policies,
           clc_v2_alerts_returns_a_single_policy,
-          clc_v2_alerts_creates_expected_policy
+          clc_v2_alerts_creates_expected_policy,
+          clc_v2_alerts_updates_expected_policy
          ].
 
 suite() ->
@@ -51,7 +53,7 @@ clc_v2_alerts_creates_expected_policy(Config) ->
                   [#{ <<"action">> => <<"email">>,
                       <<"settings">> => #{ <<"recipients">> => [<<"r1@host.com">>, <<"r2@host.com">>] }
                   }],
-                <<"triggers">> => 
+                <<"triggers">> =>
                   [#{ <<"metric">> => <<"cpu">>, <<"duration">> => <<"00:00:01">>, <<"threshold">> => 67.8 },
                    #{ <<"metric">> => <<"memory">>, <<"duration">> => <<"01:23:45">>, <<"threshold">> => 0.12 }
                   ]
@@ -60,9 +62,32 @@ clc_v2_alerts_creates_expected_policy(Config) ->
 
   AuthRef = proplists:get_value( auth_ref, Config ),
   Id = clc_v2:create_alert_policy(AuthRef, Spec),
- 
+
   assert:equal(Expected, data_server:get(alert_policies, Id)),
   ok.
+
+clc_v2_alerts_updates_expected_policy(Config) ->
+  Spec = #{name => <<"p1">>,
+           email_recipients => [<<"r1@host.com">>],
+           triggers => [ #{ metric => cpu, duration => <<"00:00:01">>, threshold => 67.8 } ]
+          },
+
+  Expected = #{ <<"name">> => <<"p1">>,
+                <<"actions">> =>
+                  [#{ <<"action">> => <<"email">>,
+                      <<"settings">> => #{ <<"recipients">> => [<<"r1@host.com">>] }
+                  }],
+                <<"triggers">> =>
+                  [#{ <<"metric">> => <<"cpu">>, <<"duration">> => <<"00:00:01">>, <<"threshold">> => 67.8 } ]
+              },
+
+  Id = 123,
+  AuthRef = proplists:get_value( auth_ref, Config ),
+  clc_v2:update_alert_policy(AuthRef, Spec, Id),
+
+  assert:equal(Expected, data_server:get(alert_policies, Id)),
+  ok.
+
 
 random_policies() ->
   Items = [random_policy(),

--- a/uats/assert.erl
+++ b/uats/assert.erl
@@ -1,22 +1,8 @@
 -module(assert).
 -export([equal/2]).
 
-equal(Expected, Actual) when is_map(Expected) ->
-  Keys = maps:keys(Expected),
-  ValuesEqual = fun(Key) ->
-                    Expected1 = maps:get(Key,Expected),
-                    Actual1 = maps:get(Key,Actual),
-                    equal(Expected1,Actual1)
-                end,
-  lists:all(ValuesEqual, Keys);
-equal([Expected | ExpectedTail], [Actual | ActualTail])
-                                  when is_integer(Expected) =:= false ->
-  equal(Expected, Actual),
-  equal(ExpectedTail, ActualTail);
-equal([],[]) ->
-  true;
 equal(Expected, Actual) ->
-  ct:pal("  expected: ~p~n    actual: ~p~n", [Expected,Actual]),
-  Expected =:= Actual.
+  ct:pal("  expected: ~p~n    actual: ~p~n", [Expected, Actual]),
+  Expected = Actual.
 
 

--- a/uats/datacenters_SUITE.erl
+++ b/uats/datacenters_SUITE.erl
@@ -25,7 +25,7 @@ clc_v2_datacenters_returns_expected_datacenters(Config) ->
   data_server:put(datacenters, Expected),
 
   AuthRef = proplists:get_value( auth_ref, Config ),
-  Actual = clc_v2:datacenters(AuthRef),
+  { ok, Actual } = clc_v2:datacenters(AuthRef),
 
   assert:equal(Expected, Actual),
   ok.
@@ -35,7 +35,7 @@ clc_v2_datacenter_returns_a_single_datacenter(Config) ->
   data_server:put(datacenters, Id, Expected),
 
   AuthRef = proplists:get_value( auth_ref, Config ),
-  Actual = clc_v2:datacenter(AuthRef, Id),
+  { ok, Actual } = clc_v2:datacenter(AuthRef, Id),
 
   assert:equal(Expected, Actual),
   ok.
@@ -46,7 +46,7 @@ clc_v2_datacenter_capabilities_returns_capabilites_for_a_datacenter(Config) ->
   data_server:put(datacenter_capabilities, Datacenter, Expected),
 
   AuthRef = proplists:get_value( auth_ref, Config ),
-  Actual = clc_v2:datacenter_capabilities(AuthRef, Datacenter),
+  { ok, Actual } = clc_v2:datacenter_capabilities(AuthRef, Datacenter),
 
   assert:equal(Expected, Actual),
   ok.

--- a/uats/mock_clc/src/alertpolicy_handler.erl
+++ b/uats/mock_clc/src/alertpolicy_handler.erl
@@ -10,7 +10,8 @@
          forbidden/2,
          unsupported/2,
          read/2,
-         write/2]).
+         write/2,
+         delete_resource/2]).
 
 init(_ReqType, _Req, _Options) ->
   {upgrade, protocol, cowboy_rest}.
@@ -19,7 +20,7 @@ rest_init(Req, _Opts) ->
   {ok, Req, undefined_state}.
 
 allowed_methods(Req, State) ->
-  {[<<"GET">>, <<"POST">>, <<"PUT">>], Req, State}.
+  {[<<"GET">>, <<"POST">>, <<"PUT">>, <<"DELETE">>], Req, State}.
 
 content_types_provided(Req, State) ->
   {[
@@ -63,6 +64,14 @@ write(Req, State) ->
 
   {ok, Response} = cowboy_req:reply(200, [], jiffy:encode(#{<<"id">> => Id}), Req),
   {ok, Response, State}.
+
+delete_resource(Req, State) ->
+  Id = element(1, cowboy_req:binding(id, Req)),
+
+  data_server:put(alert_policies, Id, deleted),
+
+  {true, Req, State}.
+
 
 get_policies(undefined) ->
   data_server:get(alert_policies);

--- a/uats/mock_clc/src/alertpolicy_handler.erl
+++ b/uats/mock_clc/src/alertpolicy_handler.erl
@@ -39,5 +39,12 @@ unsupported(Req, State) ->
   {ok, Response, State}.
 
 get(Req, State) ->
-  Response = data_server:get(alert_policies),
+  Id = element(1, cowboy_req:binding(id, Req)),
+  Response = get_policies(Id),
   {jiffy:encode(Response), Req, State}.
+
+get_policies(undefined) ->
+  data_server:get(alert_policies);
+get_policies(Id) ->
+  data_server:get(alert_policies, Id).
+

--- a/uats/mock_clc/src/alertpolicy_handler.erl
+++ b/uats/mock_clc/src/alertpolicy_handler.erl
@@ -19,7 +19,7 @@ rest_init(Req, _Opts) ->
   {ok, Req, undefined_state}.
 
 allowed_methods(Req, State) ->
-  {[<<"GET">>, <<"POST">>], Req, State}.
+  {[<<"GET">>, <<"POST">>, <<"PUT">>], Req, State}.
 
 content_types_provided(Req, State) ->
   {[
@@ -30,7 +30,7 @@ content_types_provided(Req, State) ->
 content_types_accepted(Req, State) ->
   {[
     {<<"*">>, unsupported},
-    {<<"application/json">>, write} 
+    {<<"application/json">>, write}
    ],Req, State}.
 
 is_authorized(Req, State) ->
@@ -53,8 +53,8 @@ read(Req, State) ->
 
 write(Req, State) ->
   Id = case cowboy_req:method(Req) of
-         {<<"POST">>, _} -> integer_to_binary(element(3, now())); 
-         _ -> element(1, cowboy_req:binding(id, Req)) 
+         {<<"POST">>, _} -> integer_to_binary(element(3, now()));
+         _ -> element(1, cowboy_req:binding(id, Req))
        end,
   {ok, Body, _} = cowboy_req:body(Req),
   Spec = jiffy:decode(Body, [return_maps]),

--- a/uats/mock_clc/src/auth_handler.erl
+++ b/uats/mock_clc/src/auth_handler.erl
@@ -4,6 +4,7 @@
          rest_init/2,
          allowed_methods/2,
          content_types_accepted/2,
+         content_types_provided/2,
          post/2]).
 
 init(_ReqType, _Req, _Options) ->
@@ -16,6 +17,9 @@ allowed_methods(Req, State) ->
   {[<<"POST">>], Req, State}.
 
 content_types_accepted(Req, State) ->
+  {[{{<<"application">>, <<"json">>, []}, post}], Req, State}.
+
+content_types_provided(Req, State) ->
   {[{{<<"application">>, <<"json">>, []}, post}], Req, State}.
 
 post(Req, State) ->

--- a/uats/mock_clc/src/mock_clc_app.erl
+++ b/uats/mock_clc/src/mock_clc_app.erl
@@ -22,9 +22,13 @@ route_matchers() ->
 
   [ {'_',
      [
-      { "/v2/authentication/login", auth_handler, [] },
-      { "/v2/alertPolicies/" ++ ?ALIAS, alertpolicy_handler, [] },
-      { "/v2/datacenters/" ++ ?ALIAS ++ "/[:id]", datacenter_handler, [] },
-      { "/v2/datacenters/" ++ ?ALIAS ++ "/:id/deploymentCapabilities", dc_capability_handler, [] }
+      { "/v2/authentication/login",
+          auth_handler, [] },
+      { io_lib:format("/v2/alertPolicies/~s", [?ALIAS]),
+          alertpolicy_handler, [] },
+      { io_lib:format("/v2/datacenters/~s/[:id]", [?ALIAS]),
+          datacenter_handler, [] },
+      { io_lib:format("/v2/datacenters/~s/:id/deploymentCapabilities", [?ALIAS]),
+          dc_capability_handler, [] }
      ]
     } ].

--- a/uats/mock_clc/src/mock_clc_app.erl
+++ b/uats/mock_clc/src/mock_clc_app.erl
@@ -24,7 +24,7 @@ route_matchers() ->
      [
       { "/v2/authentication/login",
           auth_handler, [] },
-      { io_lib:format("/v2/alertPolicies/~s", [?ALIAS]),
+      { io_lib:format("/v2/alertPolicies/~s/[:id]", [?ALIAS]),
           alertpolicy_handler, [] },
       { io_lib:format("/v2/datacenters/~s/[:id]", [?ALIAS]),
           datacenter_handler, [] },

--- a/uats/uat_helper.hrl
+++ b/uats/uat_helper.hrl
@@ -4,7 +4,7 @@
   {ok, _} = application:ensure_all_started( clc_v2 ),
   ok = application:set_env(clc_v2, api_base, "http://localhost:8000/v2"),
   {ok, _} = application:ensure_all_started( mock_clc, temporary ),
-  AuthRef = clc_v2:login( <<"mock_user">>, <<"mock_password">>),
+  { ok, AuthRef } = clc_v2:login( <<"mock_user">>, <<"mock_password">>),
   [{ auth_ref, AuthRef } | Config ] ).
 -define( SUITE_TEARDOWN(),
   application:stop( clc_v2 ),


### PR DESCRIPTION
Implementation of [Alert Policies API](https://www.ctl.io/api-docs/v2/#alert-policies)

Note error handling introduced in ecc7c7 and accompanying interface changes in d275aa - I was really trying avoid having test ```ok``` for every response before extracting the response payload.

Also there are some deviations from the API. For example, I do not echo the entire policy upon creation, only the delta (ie. the assigned identifier). Also, the policy schema itself is much condensed. Maybe this makes the SDK worse in some imaginary future iteration of the API, but for now it seems to provide a better experience.